### PR TITLE
POSIX.pm in Perl v5.21.1+ exports `round()` by default.

### DIFF
--- a/lib/Geo/Coordinates/Converter/Format/Dms.pm
+++ b/lib/Geo/Coordinates/Converter/Format/Dms.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use parent 'Geo::Coordinates::Converter::Format';
 
-use POSIX;
+use POSIX ();
 
 our $DIGITS = 3;
 
@@ -37,8 +37,8 @@ sub from {
     for my $meth (qw/ lat lng /) {
         my($ws, $degree) = $point->$meth =~ /^(\-?)(.+)$/;
         
-        my $deg  = floor($degree);
-        my $min  = floor(($degree - $deg) * 60 % 60);
+        my $deg  = POSIX::floor($degree);
+        my $min  = POSIX::floor(($degree - $deg) * 60 % 60);
         my $sec  = ($degree - $deg) * 3600 - $min * 60;
         $point->$meth(sprintf "%s%s.%s.%s", $ws || '', $deg, $min, $sec);
     }

--- a/lib/Geo/Coordinates/Converter/Format/ISO6709.pm
+++ b/lib/Geo/Coordinates/Converter/Format/ISO6709.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use parent 'Geo::Coordinates::Converter::Format';
 
-use POSIX;
+use POSIX ();
 
 use Geo::Coordinates::Converter::Format::Dms;
 

--- a/lib/Geo/Coordinates/Converter/Format/Milliseconds.pm
+++ b/lib/Geo/Coordinates/Converter/Format/Milliseconds.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use parent 'Geo::Coordinates::Converter::Format';
 
-use POSIX;
+use POSIX ();
 
 sub name { 'milliseconds' }
 
@@ -36,7 +36,7 @@ sub from {
 
 sub round {
     my($self, $val) = @_;
-    ceil($val);
+    POSIX::ceil($val);
 }
 
 1;


### PR DESCRIPTION
Perl v5.2.1+ POSIX.pm exports `round()` by default.
Then, `use POSIX;` replaces `Geo::Coordinates::Converter::Format::*::round`!
